### PR TITLE
Add support for multiline strings and unquoted keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tailscale/hujson
+module go.jetpack.io/hujson
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,4 @@ module github.com/tailscale/hujson
 
 go 1.18
 
-require (
-	github.com/google/go-cmp v0.5.8
-	github.com/k0kubun/pp v3.0.1+incompatible
-)
-
-require (
-	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.16 // indirect
-	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
-)
+require github.com/google/go-cmp v0.5.8

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,14 @@ module github.com/tailscale/hujson
 
 go 1.18
 
-require github.com/google/go-cmp v0.5.8
+require (
+	github.com/google/go-cmp v0.5.8
+	github.com/k0kubun/pp v3.0.1+incompatible
+)
+
+require (
+	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.16 // indirect
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
+github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,2 @@
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
-github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
-github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/json_test.go
+++ b/json_test.go
@@ -349,22 +349,22 @@ var testdata = []struct {
 	wantMin: `{"k":"v"}`,
 	wantStd: ` { "k" : "v" } `,
 }, {
-	in: ` { t : "v" } `,
+	in: ` { tf_0 : "v" } `,
 	want: Value{
 		BeforeExtra: Extra(" "),
 		StartOffset: 1,
 		Value: &Object{
 			Members: []ObjectMember{{
-				Value{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal("t"), EndOffset: 4, AfterExtra: Extra(" ")},
-				Value{BeforeExtra: Extra(" "), StartOffset: 7, Value: Literal(`"v"`), EndOffset: 10},
+				Value{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal("tf_0"), EndOffset: 7, AfterExtra: Extra(" ")},
+				Value{BeforeExtra: Extra(" "), StartOffset: 10, Value: Literal(`"v"`), EndOffset: 13},
 			}},
 			AfterExtra: Extra(" "),
 		},
-		EndOffset:  12,
+		EndOffset:  15,
 		AfterExtra: Extra(" "),
 	},
-	wantMin: `{"t":"v"}`,
-	wantStd: ` { "t" : "v" } `,
+	wantMin: `{"tf_0":"v"}`,
+	wantStd: ` { "tf_0" : "v" } `,
 }}
 
 func Test(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -372,6 +372,22 @@ var testdata = []struct {
 		EndOffset: 3,
 	},
 	wantErr: fmt.Errorf("hujson: line 1, column 4: %w", fmt.Errorf("invalid character 'f' after top-level value")),
+}, {
+	in: "[foo]",
+	want: Value{
+		StartOffset: 0,
+		Value: &Array{
+			Elements: nil,
+		},
+		EndOffset: 0,
+	},
+	wantErr: fmt.Errorf("hujson: line 1, column 2: %w", fmt.Errorf("invalid character 'f' at start of array value")),
+}, {
+	in: `{"k": v }`,
+	want: Value{Value: &Object{
+		Members: nil,
+	}},
+	wantErr: fmt.Errorf("hujson: line 1, column 7: %w", errors.New("invalid character 'v' at start of object value")),
 }}
 
 func Test(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -388,6 +388,18 @@ var testdata = []struct {
 		Members: nil,
 	}},
 	wantErr: fmt.Errorf("hujson: line 1, column 7: %w", errors.New("invalid character 'v' at start of object value")),
+}, {
+	in: `{0: "v"}`,
+	want: Value{Value: &Object{
+		Members: nil,
+	}},
+	wantErr: fmt.Errorf("hujson: line 1, column 2: %w", errors.New("invalid character '0' at start of object name")),
+}, {
+	in: `{.: "v"}`,
+	want: Value{Value: &Object{
+		Members: nil,
+	}},
+	wantErr: fmt.Errorf("hujson: line 1, column 2: %w", errors.New("invalid literal: .")),
 }}
 
 func Test(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -400,6 +400,12 @@ var testdata = []struct {
 		Members: nil,
 	}},
 	wantErr: fmt.Errorf("hujson: line 1, column 2: %w", errors.New("invalid literal: .")),
+}, {
+	in: `{foo+a: "v"}`,
+	want: Value{Value: &Object{
+		Members: nil,
+	}},
+	wantErr: fmt.Errorf("hujson: line 1, column 2: %w", errors.New("invalid literal: foo+a")),
 }}
 
 func Test(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -331,6 +331,40 @@ var testdata = []struct {
 	want:    Value{Value: Literal("`1\\\n2`"), EndOffset: 6},
 	wantMin: `"12"`,
 	wantStd: `"12"`,
+}, {
+	in: " { k : `v` } ",
+	want: Value{
+		BeforeExtra: Extra(" "),
+		StartOffset: 1,
+		Value: &Object{
+			Members: []ObjectMember{{
+				Value{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal("k"), EndOffset: 4, AfterExtra: Extra(" ")},
+				Value{BeforeExtra: Extra(" "), StartOffset: 7, Value: Literal("`v`"), EndOffset: 10},
+			}},
+			AfterExtra: Extra(" "),
+		},
+		EndOffset:  12,
+		AfterExtra: Extra(" "),
+	},
+	wantMin: `{"k":"v"}`,
+	wantStd: ` { "k" : "v" } `,
+}, {
+	in: ` { t : "v" } `,
+	want: Value{
+		BeforeExtra: Extra(" "),
+		StartOffset: 1,
+		Value: &Object{
+			Members: []ObjectMember{{
+				Value{BeforeExtra: Extra(" "), StartOffset: 3, Value: Literal("t"), EndOffset: 4, AfterExtra: Extra(" ")},
+				Value{BeforeExtra: Extra(" "), StartOffset: 7, Value: Literal(`"v"`), EndOffset: 10},
+			}},
+			AfterExtra: Extra(" "),
+		},
+		EndOffset:  12,
+		AfterExtra: Extra(" "),
+	},
+	wantMin: `{"t":"v"}`,
+	wantStd: ` { "t" : "v" } `,
 }}
 
 func Test(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -365,6 +365,13 @@ var testdata = []struct {
 	},
 	wantMin: `{"tf_0":"v"}`,
 	wantStd: ` { "tf_0" : "v" } `,
+}, {
+	in: "foo",
+	want: Value{
+		Value:     Literal("foo"),
+		EndOffset: 3,
+	},
+	wantErr: fmt.Errorf("hujson: line 1, column 4: %w", fmt.Errorf("invalid character 'f' after top-level value")),
 }}
 
 func Test(t *testing.T) {

--- a/parse.go
+++ b/parse.go
@@ -92,7 +92,7 @@ func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
 				}
 				return &obj, n, err
 			}
-			if vk.Value.Kind() != '"' {
+			if vk.Value.Kind() != '"' && vk.Value.Kind() != '`' {
 				return &obj, vk.StartOffset, newInvalidCharacterError(b[vk.StartOffset:], "at start of object name")
 			}
 
@@ -162,7 +162,8 @@ func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
 		return nil, n, errInvalidArrayEnd
 
 	// Parse strings.
-	case '"':
+	case '"', '`':
+		delim := b[n]
 		n0 := n
 		n++
 		var inEscape bool
@@ -174,7 +175,7 @@ func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
 				inEscape = false
 			case b[n] == '\\':
 				inEscape = true
-			case b[n] == '"':
+			case b[n] == delim:
 				n++
 				lit := Literal(b[n0:n:n])
 				if !lit.IsValid() {

--- a/parse.go
+++ b/parse.go
@@ -197,7 +197,7 @@ func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
 	// Parse null, booleans, and numbers.
 	default:
 		n0 := n
-		for len(b) > n && (b[n] == '-' || b[n] == '+' || b[n] == '.' ||
+		for len(b) > n && (b[n] == '-' || b[n] == '+' || b[n] == '.' || b[n] == '_' ||
 			('a' <= b[n] && b[n] <= 'z') ||
 			('A' <= b[n] && b[n] <= 'Z') ||
 			('0' <= b[n] && b[n] <= '9')) {

--- a/parse.go
+++ b/parse.go
@@ -26,6 +26,10 @@ func Parse(b []byte) (Value, error) {
 	if err == nil && n < len(b) {
 		err = newInvalidCharacterError(b[n:], "after top-level value")
 	}
+	// Identifiers can't be top-level values.
+	if v.Value != nil && v.Value.Kind() == 'a' {
+		err = newInvalidCharacterError(b[v.StartOffset:], "after top-level value")
+	}
 	if err != nil {
 		line, column := lineColumn(b, n)
 		err = fmt.Errorf("hujson: line %d, column %d: %w", line, column, err)

--- a/parse.go
+++ b/parse.go
@@ -92,7 +92,7 @@ func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
 				}
 				return &obj, n, err
 			}
-			if vk.Value.Kind() != '"' && vk.Value.Kind() != '`' {
+			if vk.Value.Kind() != '"' && vk.Value.Kind() != '`' && vk.Value.Kind() != 'a' {
 				return &obj, vk.StartOffset, newInvalidCharacterError(b[vk.StartOffset:], "at start of object name")
 			}
 
@@ -108,6 +108,10 @@ func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
 			// Parse the value.
 			if vv, n, err = parseNext(n, b); err != nil {
 				return &obj, n, err
+			}
+			// Identifiers are only allowed as keys.
+			if vv.Value.Kind() == 'a' {
+				return &obj, vv.StartOffset, newInvalidCharacterError(b[vv.StartOffset:], "at start of object value")
 			}
 
 			obj.Members = append(obj.Members, ObjectMember{vk, vv})
@@ -142,6 +146,10 @@ func parseNextTrimmed(n int, b []byte) (ValueTrimmed, int, error) {
 					return &arr, n + len(`]`), nil
 				}
 				return &arr, n, err
+			}
+			// Identifiers are only allowed as keys.
+			if v.Value.Kind() == 'a' {
+				return &arr, v.StartOffset, newInvalidCharacterError(b[v.StartOffset:], "at start of array value")
 			}
 			arr.Elements = append(arr.Elements, v)
 			switch {

--- a/standard.go
+++ b/standard.go
@@ -20,7 +20,7 @@ func (v *Value) isStandard() bool {
 			return false
 		}
 	} else {
-		if v.Value.Kind() == '`' {
+		if v.Value.Kind() == '`' || v.Value.Kind() == 'a' {
 			return false
 		}
 	}
@@ -96,6 +96,9 @@ func standardizedLiteral(src Literal) Literal {
 	if src.Kind() == '`' {
 		return standardizedMultiString(src)
 	}
+	if src.Kind() == 'a' {
+		return standarizedIdentifier(src)
+	}
 	return src
 }
 
@@ -136,5 +139,13 @@ func standardizedMultiString(src Literal) Literal {
 		// Default case, just append the character
 		result = append(result, c)
 	}
+	return result
+}
+
+func standarizedIdentifier(src Literal) Literal {
+	result := make([]byte, 0, len(src)+2)
+	result = append(result, '"')
+	result = append(result, src...)
+	result = append(result, '"')
 	return result
 }

--- a/standard.go
+++ b/standard.go
@@ -4,8 +4,7 @@
 
 package hujson
 
-// IsStandard reports whether this is standard JSON
-// by checking that there are no comments and no trailing commas.
+// IsStandard reports whether this is standard JSON.
 func (v Value) IsStandard() bool {
 	return v.isStandard()
 }
@@ -18,6 +17,10 @@ func (v *Value) isStandard() bool {
 			return false
 		}
 		if hasTrailingComma(comp) || !comp.afterExtra().IsStandard() {
+			return false
+		}
+	} else {
+		if v.Value.Kind() == '`' {
 			return false
 		}
 	}
@@ -48,6 +51,9 @@ func (v *Value) minimize() bool {
 		setTrailingComma(v2, false)
 		*v2.afterExtra() = nil
 	}
+	if lit, ok := v.Value.(Literal); ok {
+		v.Value = standardizedLiteral(lit)
+	}
 	v.AfterExtra = nil
 	return true
 }
@@ -70,6 +76,9 @@ func (v *Value) standardize() bool {
 		}
 		comp.afterExtra().standardize()
 	}
+	if lit, ok := v.Value.(Literal); ok {
+		v.Value = standardizedLiteral(lit)
+	}
 	v.AfterExtra.standardize()
 	return true
 }
@@ -82,4 +91,50 @@ func (b *Extra) standardize() {
 			(*b)[i] = ' '
 		}
 	}
+}
+func standardizedLiteral(src Literal) Literal {
+	if src.Kind() == '`' {
+		return standardizedMultiString(src)
+	}
+	return src
+}
+
+func standardizedMultiString(src Literal) Literal {
+	// Convert multiline strings into regular JSON strings:
+	result := make([]byte, 0, len(src)+10)
+	escapeNext := false
+	for i, c := range src {
+		// Replace initial/final backticks with double quotes.
+		if i == 0 || i == len(src)-1 {
+			result = append(result, `"`...)
+			continue
+		}
+
+		// Handle escape sequences
+		if c == '\\' {
+			escapeNext = true
+			continue
+		} else if escapeNext {
+			escapeNext = false
+			switch c {
+			case '`':
+				result = append(result, '`')
+			case '\n':
+				// Ignore the newline if it's been escaped
+			default:
+				result = append(result, '\\', c)
+			}
+			continue
+		}
+
+		// Escape newline characters
+		if c == '\n' {
+			result = append(result, `\n`...)
+			continue
+		}
+
+		// Default case, just append the character
+		result = append(result, c)
+	}
+	return result
 }


### PR DESCRIPTION
Fork the hujson library from tailscale to add two changes to it:

1. Support multiline strings using backticks. This follows the notation for template literals in ECMAScript 6 (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)

2. Allows for unquoted keys when the key is a valid identifier. This is something that is also allowed by ECMAScript 6 and we're following almost the same rules (we're technically a little bit stricter because we do not allow `true`, `false` and `null` as they would complicate the implementation, and in practice I don't think we'll need those unquoted).

Added lots of new tests to make sure the library works with those changes.